### PR TITLE
Fix SpeedPerturb input arg

### DIFF
--- a/recipes/LibriSpeech/ASR/transformer/hparams/branchformer_summarymixing.yaml
+++ b/recipes/LibriSpeech/ASR/transformer/hparams/branchformer_summarymixing.yaml
@@ -298,6 +298,7 @@ epoch_counter: !new:speechbrain.utils.epoch_loop.EpochCounter
 
 # Speed perturbation
 speed_perturb: !new:speechbrain.augment.time_domain.SpeedPerturb
+    orig_freq: !ref <sample_rate>
     speeds: [95, 100, 105]
 
 # Time Drop


### PR DESCRIPTION
Hi,

This PR fix an issue with the provided yaml. Indeed,  the `SpeedPerturb` is missing an input arg in the constructor which is `orig_freq`. 